### PR TITLE
fix: remove role na rota de delete de usuário

### DIFF
--- a/src/models/users/users.controller.ts
+++ b/src/models/users/users.controller.ts
@@ -103,7 +103,6 @@ export class UsersController {
     return response;
   }
 
-  @Roles(Role.ADMIN, Role.FISCAL)
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
   @Delete(':id')


### PR DESCRIPTION
Essa rota não deveria ser avaliada pelo cargo, mas por permissões, nesse caso, como as permissões não foram implementadas, tirei o guard de roles